### PR TITLE
Removed note about submission deadline extension

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,10 +4,6 @@ title: AI for Earth and Space Science
 ---
 ---
 
-## Submission deadline extension
-
-We are extending the submission deadline from Feb 26 at 12:00 AM UTC to February 28th at 12:00 AM AOE. In other words, we will be accepting submissions until the end of Sunday AOE.
-
 ## Workshop description
 
 This workshop aims to highlight work being done at the intersection of AI and the Earth and Space Sciences, with a special focus on model interpretability at the ICLR 2022 iteration of the workshop. 


### PR DESCRIPTION
Since the deadline has passed, this no longer needs to be the first thing people see when they come to the site.